### PR TITLE
Add optional profile to build a small binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,12 @@
 [workspace]
 members = ["railwind", "railwind_cli"]
+
+
+
+[profile.small]
+inherits = 'release'
+opt-level = 'z'     # Optimize for size
+lto = true          # Enable link-time optimization
+codegen-units = 1   # Reduce number of codegen units to increase optimizations
+panic = 'abort'     # Abort on panic
+strip = true        # Strip symbols from binary*


### PR DESCRIPTION
This makes it possible to build with --profile=small if the user wants to optimize for a small binary.